### PR TITLE
1.5.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 Contributors: gnpublisher  
 Tags: google news, news, rss, feed, feeds  
 Requires at least: 3.5  
-Tested up to: 6.7  
+Tested up to: 6.8  
 Requires PHP: 5.4  
-Stable tag: 1.5.18  
+Stable tag: 1.5.22  
 License: GPLv3  
 License URI: https://www.gnu.org/licenses/gpl-3.0.html  
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+= 1.5.22 - (13 May 2025) =
+
+* Fixed : Some WordPress Core feed redirects to attachment URL when GN publisher is active #126
+* Test : Need to test with WordPress 6.8 #124
+
 = 1.5.21 - (05 April 2025) =
 
 * Fixed : News Sitemap Not Updating & Category Display Improvement #120

--- a/class-gnpub-rss-url.php
+++ b/class-gnpub-rss-url.php
@@ -61,7 +61,7 @@ class Gnpub_Rss_Url {
         $name = get_query_var( 'category_name' );
         $page = get_page_by_path( $name );
 
-        if ( ! empty( $page ) ) {
+        if ( ! empty( $page ) &&  $page->post_type === 'page' ) {
             wp_safe_redirect( get_post_comments_feed_link( $page->ID ) );
             die;
         }

--- a/gn-publisher.php
+++ b/gn-publisher.php
@@ -7,7 +7,7 @@
  * Plugin Name: GN Publisher
  * Plugin URI: https://gnpublisher.com/
  * Description: GN Publisher: The easy way to make Google News Publisher compatible RSS feeds.
- * Version: 1.5.21
+ * Version: 1.5.22
  * Author: Chris Andrews
  * Author URI: https://gnpublisher.com/
  * Text Domain: gn-publisher
@@ -40,7 +40,7 @@ function gnpub_feed_bootstrap() {
 		return;
 	}
  
-	define( 'GNPUB_VERSION', '1.5.21' );
+	define( 'GNPUB_VERSION', '1.5.22' );
 	define( 'GNPUB_PATH', plugin_dir_path( __FILE__ ) );
     define( 'GNPUB_URL', plugins_url( '', __FILE__) );
 	define( 'GNPUB_PLUGIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: gnpublisher
 Tags: google news, news, rss, feed, feeds
 Requires at least: 3.5
-Tested up to: 6.7
+Tested up to: 6.8
 Requires PHP: 5.4
-Stable tag: 1.5.21
+Stable tag: 1.5.22
 License: GPLv3 
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -89,6 +89,11 @@ GN Publisher may also be downloaded to your computer and uploaded, installed, an
 
 == Changelog ==
 
+= 1.5.22 - (13 May 2025) =
+
+* Fixed : Some WordPress Core feed redirects to attachment URL when GN publisher is active #126
+* Test : Need to test with WordPress 6.8 #124
+
 = 1.5.21 - (05 April 2025) =
 
 * Fixed : News Sitemap Not Updating & Category Display Improvement #120
@@ -149,11 +154,5 @@ GN Publisher may also be downloaded to your computer and uploaded, installed, an
 = 1.5.11.1 - (24 November 2023) =
 
 * Fixed : Warning after recent update Version 1.5.11 #79
-
-= 1.5.11 - (23 November 2023) =
-
-* Added : Reader Revenue Manager support #73
-* Feature : Add 'rss2_item' Action Hook to Feed Template for Media Content #67
-* Fixed : The network deactivate button is not working on the wp-multisite #75
 
 Full changelog available at [changelog.txt](https://plugins.svn.wordpress.org/gn-publisher/trunk/changelog.txt)


### PR DESCRIPTION
= 1.5.22 - (13 May 2025) =

* Fixed : Some WordPress Core feed redirects to attachment URL when GN publisher is active #126
* Test : Need to test with WordPress 6.8 #124